### PR TITLE
Fix pad left on seconds and microseconds

### DIFF
--- a/lib/ulid.ex
+++ b/lib/ulid.ex
@@ -5,6 +5,13 @@ defmodule Ulid do
   def generate do
     milliseconds_timestamp = :os.timestamp
       |> Tuple.to_list
+      |> Enum.with_index
+      |> Enum.map(
+        fn
+          ({k, i}) when i == 1 or i == 2 -> Integer.to_string(k) |> String.rjust(6, ?0)
+          ({k, _}) -> Integer.to_string(k)
+        end
+      )
       |> Enum.join
       |> String.to_integer
       |> (&(&1 / 1000)).()


### PR DESCRIPTION
This change resolves an issue where seconds and microseconds were joined without a leading 0.