### PR TITLE
Various small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,44 @@ r is Randomness
 
 ## Test Suite
 
-```
+```sh
 mix test
+```
+
+### Benchmarking
+
+To run the benchmarks yourself, just do the following
+
+```sh
+mix run bench/ulid_bench.exs
+```
+
+```
+Operating System: Linux
+CPU Information: Intel(R) Xeon(R) CPU E5-2630 v2 @ 2.60GHz
+Number of Available Cores: 24
+Available memory: 62.92 GB
+Elixir 1.8.2
+Erlang 22.0.7
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: none specified
+Estimated total run time: 14 s
+
+Benchmarking generate...
+Benchmarking generate_binary...
+
+Name                      ips        average  deviation         median         99th %
+generate_binary      484.37 K        2.06 μs  ±1231.73%        1.91 μs        2.75 μs
+generate             159.64 K        6.26 μs   ±417.75%        5.56 μs       12.53 μs
+
+Comparison:
+generate_binary      484.37 K
+generate             159.64 K - 3.03x slower +4.20 μs
 ```
 
 ### Credits and references:

--- a/bench/ulid_bench.exs
+++ b/bench/ulid_bench.exs
@@ -1,13 +1,6 @@
-defmodule UlidBench do
-  use Benchfella
-
-  bench "generate" do
-    Ulid.generate()
-    nil
-  end
-
-  bench "generate_binary" do
-    Ulid.generate_binary()
-    nil
-  end
-end
+Benchee.run(
+  %{
+    "generate" => fn -> Ulid.generate() end,
+    "generate_binary" => fn -> Ulid.generate_binary() end
+  }
+)

--- a/lib/ulid.ex
+++ b/lib/ulid.ex
@@ -1,9 +1,13 @@
 defmodule Ulid do
-  def generate(timestamp \\ System.system_time(:milli_seconds)) do
+  @type t :: binary()
+
+  @spec generate(pos_integer()) :: t()
+  def generate(timestamp \\ System.system_time(:millisecond)) do
     Ulid.Utils.encode(generate_binary(timestamp))
   end
 
-  def generate_binary(timestamp \\ System.system_time(:milli_seconds)) do
+  @spec generate_binary(pos_integer()) :: t()
+  def generate_binary(timestamp \\ System.system_time(:millisecond)) do
     <<timestamp::unsigned-size(48), :crypto.strong_rand_bytes(10)::binary>>
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,6 +1,7 @@
 defmodule Ulid.Utils do
   @encoding "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
+  @spec encode(binary()) :: binary()
   def encode(<<_::unsigned-size(128)>> = bytes), do: encode_bytes(<<0::2, bytes::binary>>, <<>>)
 
   defp encode_bytes(<<index::unsigned-size(5), rest::bitstring>>, acc) do

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,9 @@ defmodule Ulid.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:benchfella, "~> 0.3.5", only: [:dev, :test]}]
+    [
+      {:benchee, "~> 1.0", only: [:dev, :test]}
+    ]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
 %{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Fixed some deprecated calls

```
iex(1)> System.system_time(:milliseconds) 
warning: deprecated time unit: :milliseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
```

Replaced Benchfella with Benchee https://github.com/bencheeorg/benchee

Added some type specs